### PR TITLE
ENG-317: price wire float→double (Phase A, server)

### DIFF
--- a/history/src/servers/history/run.ts
+++ b/history/src/servers/history/run.ts
@@ -25,7 +25,9 @@ const listPrices = wrapAsyncToRunInSpan({
   fnName: "listPrices",
   fn: async (
     { request }: grpc.ServerUnaryCall<GetPriceHistoryArgs, unknown>,
-    callback: grpc.sendUnaryData<{ priceHistory: Tick[] }>,
+    callback: grpc.sendUnaryData<{
+      priceHistory: Array<Tick & { price_v2: number }>
+    }>,
   ) => {
     const { currency, range } = request
     const priceHistory = await History.getPriceHistory({ currency, range })
@@ -40,7 +42,17 @@ const listPrices = wrapAsyncToRunInSpan({
       })
     }
 
-    return callback(null, { priceHistory })
+    // ENG-317 / Phase A: populate both `price` (deprecated float32) and
+    // `price_v2` (double) on every Tick from the same source value. The
+    // wire will quantise `price` through float32; `price_v2` preserves
+    // the full float64. See realtime/run.ts and the proto for the full
+    // rollout plan.
+    const priceHistoryWithDouble = priceHistory.map((t) => ({
+      ...t,
+      price_v2: t.price,
+    }))
+
+    return callback(null, { priceHistory: priceHistoryWithDouble })
   },
 })
 

--- a/history/src/servers/protos/price_history.proto
+++ b/history/src/servers/protos/price_history.proto
@@ -22,5 +22,10 @@ message PriceHistoryResponse {
 
 message Tick {
   uint64 timestamp = 1;
-  float price = 2;
+  // ENG-317 / Phase A of float→double rollout. See price.proto for the full
+  // rationale. Servers MUST populate both fields; clients SHOULD prefer
+  // `price_v2` and fall back to `price` when the server has not yet been
+  // upgraded. `float price = 2` will be removed in Phase B.
+  float price = 2 [deprecated = true];
+  double price_v2 = 3;
 }

--- a/realtime/src/servers/protos/price.proto
+++ b/realtime/src/servers/protos/price.proto
@@ -6,7 +6,21 @@ service PriceFeed {
 }
 
 message PriceResponse {
-  float price = 1;
+  // ENG-317 / Phase A of float→double rollout.
+  //
+  // `price` (float32) is lossy for non-USD/non-BTC currencies — the JMD
+  // round-trip exhibited ~J$0.80 of drift, see ENG-316 / lnflash/flash#282.
+  // It is preserved here at its original tag for wire compatibility with
+  // pre-ENG-317 clients and servers, and is marked deprecated.
+  //
+  // Servers MUST populate both `price` and `price_v2` for the duration of
+  // Phase A. Clients SHOULD prefer `price_v2` and fall back to `price` when
+  // talking to a server that has not yet been upgraded.
+  //
+  // Phase B (future PR) will remove `float price = 1` once all clients are
+  // confirmed upgraded in prod.
+  float price = 1 [deprecated = true];
+  double price_v2 = 3;
 }
 
 message PriceQuery {

--- a/realtime/src/servers/realtime/run.ts
+++ b/realtime/src/servers/realtime/run.ts
@@ -28,7 +28,7 @@ const getPrice = wrapAsyncToRunInSpan({
   fnName: "getPrice",
   fn: async (
     { request }: grpc.ServerUnaryCall<{ currency: string }, unknown>,
-    callback: grpc.sendUnaryData<{ price: Price }>,
+    callback: grpc.sendUnaryData<{ price: Price; price_v2: Price }>,
   ) => {
     const currency = request.currency
     const price = await Realtime.getPrice(currency)
@@ -40,7 +40,13 @@ const getPrice = wrapAsyncToRunInSpan({
       })
     }
 
-    return callback(null, { price })
+    // ENG-317 / Phase A: populate both the legacy float field (`price`) and
+    // the new double field (`price_v2`) from the same source value. The
+    // float wire encoding will quantise `price` to ~24 bits of mantissa;
+    // `price_v2` carries the full float64 we computed. Clients prefer
+    // `price_v2` and fall back to `price` only when talking to a server
+    // that pre-dates this change. Phase B will drop `price` entirely.
+    return callback(null, { price, price_v2: price })
   },
 })
 


### PR DESCRIPTION
## ENG-317 — float→double on the price wire (Phase A, server side)

Pairs with **lnflash/flash#333**. Server should land first.

### What changes

- `realtime/src/servers/protos/price.proto`: add `double price_v2 = 3`
  alongside `float price = 1 [deprecated = true]` on `PriceResponse`.
- `history/src/servers/protos/price_history.proto`: same pattern on
  `Tick` (`float price = 2 [deprecated = true]; double price_v2 = 3;`).
- `realtime/src/servers/realtime/run.ts`: `getPrice` callback now
  returns `{ price, price_v2: price }` so both fields carry the same
  source value. The float wire encoding still quantises `price`;
  `price_v2` carries the full float64.
- `history/src/servers/history/run.ts`: `listPrices` maps each tick to
  `{ ...t, price_v2: t.price }` for the same reason.

### Why dual-field instead of in-place float→double

Protobuf wire types for `float` and `double` are not interchangeable
(types 5 vs 1) — swapping the type in place would silently corrupt
every reader. The additive deprecate-then-remove pattern is the only
safe rollout. Phase B (follow-up PR after one full release cycle in
prod) drops `float price` entirely from both protos and stops
populating it on the server.

### Acceptance

- [x] Server populates both `price` and `price_v2` from the same source
- [x] No change to upstream price-source code or domain layer
- [x] Wire-compatible with pre-ENG-317 clients (they keep reading
      `price` and ignore the unknown `price_v2` tag)
- [ ] Client PR (lnflash/flash#333) prefers `price_v2`
