### PR TITLE
feat(realtime): ibex-swap provider — fee-inclusive Swap Rates endpoint

### DIFF
--- a/realtime/sample-dev-custom.yaml
+++ b/realtime/sample-dev-custom.yaml
@@ -11,3 +11,15 @@ exchanges:
     # Following require dummy values
     name: ""
     cron: "*/5 * * * * *"
+  # IBEX "Swap Rates" (GET /rates) — fee/spread-inclusive executable rates,
+  # vs the legacy "ibex" provider (Rates v2, mid-market-ish, display-only).
+  # Requires IBEX_CLIENT_ID / IBEX_CLIENT_SECRET / IBEX_ENVIRONMENT.
+  - name: "IbexSwap"
+    enabled: false
+    quoteAlias: "*"
+    base: "BTC"
+    quote: "USD"
+    provider: "ibex-swap"
+    cron: "*/15 * * * * *"
+    config:
+      cacheSeconds: 180

--- a/realtime/src/config/schema.ts
+++ b/realtime/src/config/schema.ts
@@ -52,6 +52,7 @@ export const configSchema = {
               "exchangeratehost",
               "yadio",
               "ibex",
+              "ibex-swap",
             ],
           },
           cron: { type: "string" },

--- a/realtime/src/services/exchanges/ibex-swap/index.ts
+++ b/realtime/src/services/exchanges/ibex-swap/index.ts
@@ -1,0 +1,198 @@
+import { Mutex } from "async-mutex"
+import axios from "axios"
+
+import {
+  InvalidTickerError,
+  ExchangeServiceError,
+  InvalidExchangeResponseError,
+  UnknownExchangeServiceError,
+} from "@domain/exchanges"
+import { toPrice, toSeconds, toTimestamp } from "@domain/primitives"
+import { LocalCacheService } from "@services/cache"
+import { CacheKeys } from "@domain/cache"
+import { baseLogger } from "@services/logger"
+import IbexClient, { IbexUrls } from "ibex-client"
+import { AuthenticationError } from "ibex-client/dist/errors"
+import { IBEX } from "@config"
+
+import { AuthCache } from "../ibex/cache"
+import { getIbexId } from "../ibex"
+
+const mutex = new Mutex()
+
+type SwapRatesHttpResult = { status: number; body: unknown }
+
+// IBEX "Swap Rates" provider (docs.poweredbyibex.io/reference/swap-rates).
+//
+// Unlike the legacy `ibex` provider (Rates v2, mid-market-ish, display-only),
+// GET /rates returns *fee/spread-inclusive* rates for both directions, i.e.
+// the prices IBEX will actually execute swaps at. Keeping it as a separate
+// provider lets ops A/B the two via config without touching `ibex`.
+export const IbexSwapExchangeService = async ({
+  base,
+  quote,
+  config,
+}: IbexSwapExchangeServiceArgs): Promise<IExchangeService | ExchangeServiceError> => {
+  const cacheSeconds = Number(config?.cacheSeconds || 180)
+  const timeout = Number(config?.timeout || 5000)
+
+  // Same credentials, environment resolution and (redis-backed) token cache as
+  // the legacy `ibex` provider — ibex-client owns the oauth client-credentials
+  // flow. The lib does not expose GET /rates, so we issue that call ourselves
+  // against the same hub base URL, inside the lib's withAuth wrapper.
+  const Ibex = new IbexClient(
+    {
+      clientId: IBEX.clientId,
+      clientSecret: IBEX.clientSecret,
+      environment: IBEX.environment,
+    },
+    AuthCache,
+  )
+  const baseUrl = IbexUrls[IBEX.environment].hubUrl
+
+  const cacheKey = `${CacheKeys.CurrentTicker}:IbexSwap:${base}:${quote}`
+  const cacheTtlSecs = Number(cacheSeconds)
+  const cacheKeyStatus = `${cacheKey}:status`
+
+  const getCachedRates = async (): Promise<IbexSwapRates | undefined> => {
+    const cachedRates = await LocalCacheService().get<IbexSwapRates>(cacheKey)
+    if (cachedRates instanceof Error) return undefined
+    return cachedRates
+  }
+
+  const getLastRequestStatus = async (): Promise<number> => {
+    const status = await LocalCacheService().get<number>(cacheKeyStatus)
+    if (status instanceof Error) return 0
+    return status
+  }
+
+  const fetchTicker = async (): Promise<Ticker | ServiceError> => {
+    // Swap Rates responses carry no timestamp — rates are quoted "now"
+    const timestamp = new Date().getTime()
+
+    try {
+      const cachedRates = await getCachedRates()
+      if (cachedRates) return tickerFromRaw({ ...cachedRates, timestamp })
+
+      // back off until the status cache expires if the last request errored
+      const lastCachedStatus = await getLastRequestStatus()
+      if (lastCachedStatus >= 400)
+        return new UnknownExchangeServiceError(
+          `Previous request failed. Error ${lastCachedStatus}`,
+        )
+
+      const fromId = getIbexId(base)
+      const toId = getIbexId(quote)
+      if (fromId === undefined)
+        return new ExchangeServiceError(`Ibex Id not found for currency ${base}`)
+      if (toId === undefined)
+        return new ExchangeServiceError(`Ibex Id not found for currency ${quote}`)
+
+      const swapRatesRequest = async (): Promise<{ data: SwapRatesHttpResult }> => {
+        const token = await Ibex.authentication.storage.getAccessToken()
+        if (typeof token !== "string")
+          throw unauthorizedError("No IBEX access token in cache")
+
+        const response = await axios.get(`${baseUrl}/rates`, {
+          // IBEX expects the raw JWT: its openapi security scheme is an apiKey
+          // header named "Authorization", not http-bearer. A "Bearer " prefix
+          // is rejected with 401 (verified live against sandbox).
+          headers: { Authorization: token },
+          params: { from: fromId, to: toId },
+          timeout,
+          validateStatus: () => true, // HTTP errors are handled below
+        })
+
+        // a thrown { status: 401 } makes withAuth refresh the token and retry once
+        if (response.status === 401)
+          throw unauthorizedError("IBEX swap rates request unauthorized")
+
+        return { data: { status: response.status, body: response.data } }
+      }
+
+      // Reuse ibex-client's auth plumbing (cached token, refresh + single retry
+      // on 401). withAuth only ever reads `.data` off the response, so passing
+      // our plain { data } envelope through the cast is safe.
+      const authResp = await Ibex.authentication.withAuth(
+        swapRatesRequest as unknown as Parameters<typeof Ibex.authentication.withAuth>[0],
+      )
+      if (authResp instanceof AuthenticationError)
+        return new ExchangeServiceError(authResp.message)
+
+      const { status, body } = authResp as SwapRatesHttpResult
+      if (status >= 400) {
+        await LocalCacheService().set<number>({
+          key: cacheKeyStatus,
+          value: status,
+          ttlSecs: toSeconds(cacheTtlSecs > 0 ? cacheTtlSecs : 300),
+        })
+        return new UnknownExchangeServiceError(`Invalid response. Status ${status}`)
+      }
+
+      if (!isSwapRatesBodyValid(body))
+        return new InvalidExchangeResponseError(
+          "Invalid response. Missing rate or inverseRate.",
+        )
+
+      const rates: IbexSwapRates = { rate: body.rate, inverseRate: body.inverseRate }
+      await LocalCacheService().set<IbexSwapRates>({
+        key: cacheKey,
+        value: rates,
+        ttlSecs: toSeconds(cacheTtlSecs > 0 ? cacheTtlSecs : 300),
+      })
+
+      return tickerFromRaw({ ...rates, timestamp })
+    } catch (error) {
+      baseLogger.error({ error }, "IbexSwap unknown error")
+      return new UnknownExchangeServiceError(error.message || error)
+    }
+  }
+
+  return {
+    fetchTicker: () => mutex.runExclusive(fetchTicker),
+  }
+}
+
+const unauthorizedError = (message: string): Error & { status: number } =>
+  Object.assign(new Error(message), { status: 401 })
+
+const isSwapRatesBodyValid = (body: unknown): body is IbexSwapRates => {
+  if (!body || typeof body !== "object") return false
+  const { rate, inverseRate } = body as { rate?: unknown; inverseRate?: unknown }
+  return (
+    typeof rate === "number" &&
+    Number.isFinite(rate) &&
+    rate > 0 &&
+    typeof inverseRate === "number" &&
+    Number.isFinite(inverseRate) &&
+    inverseRate > 0
+  )
+}
+
+const tickerFromRaw = ({
+  rate,
+  inverseRate,
+  timestamp,
+}: {
+  rate: number
+  inverseRate: number
+  timestamp: number
+}): Ticker | InvalidTickerError => {
+  if (rate > 0 && inverseRate > 0 && timestamp > 0) {
+    // For from=base&to=quote, BOTH fields are quoted in quote-per-base units
+    // (verified live on sandbox: BTC→USD returned rate=63968.8481,
+    // inverseRate=64870.7251, with the Rates v2 mid ~64,407 sitting between):
+    //   rate        = executable base→quote side (selling base — the bid)
+    //   inverseRate = the other side of the same market (buying base — the ask)
+    // `inverseRate` is NOT a reciprocal — each side carries its own
+    // fee/spread — so there is no 1/x here; min/max keeps bid <= ask
+    // however fees land.
+    return {
+      bid: toPrice(Math.min(rate, inverseRate)),
+      ask: toPrice(Math.max(rate, inverseRate)),
+      timestamp: toTimestamp(timestamp),
+    }
+  }
+
+  return new InvalidTickerError()
+}

--- a/realtime/src/services/exchanges/ibex-swap/index.types.d.ts
+++ b/realtime/src/services/exchanges/ibex-swap/index.types.d.ts
@@ -1,0 +1,9 @@
+type IbexSwapConfig = { [key: string]: string | number | boolean }
+
+type IbexSwapRates = { rate: number; inverseRate: number }
+
+type IbexSwapExchangeServiceArgs = {
+  base: string
+  quote: string
+  config?: IbexSwapConfig
+}

--- a/realtime/src/services/exchanges/ibex/index.ts
+++ b/realtime/src/services/exchanges/ibex/index.ts
@@ -134,7 +134,8 @@ const tickerFromRaw = ({
   return new InvalidTickerError()
 }
 
-const getIbexId = (name: string) => ibexCurrencies.find((el) => el.name === name)?.id
+export const getIbexId = (name: string) =>
+  ibexCurrencies.find((el) => el.name === name)?.id
 // prettier-ignore
 const ibexCurrencies = [
       {

--- a/realtime/src/services/exchanges/index.ts
+++ b/realtime/src/services/exchanges/index.ts
@@ -8,6 +8,7 @@ import { ExchangeRatesAPIExchangeService } from "./exchange-rates-api"
 import { FreeCurrencyRatesExchangeService } from "./free-currency-rates"
 import { MockedExchangeService } from "./mocked"
 import { IbexExchangeService } from "./ibex"
+import { IbexSwapExchangeService } from "./ibex-swap"
 
 const exchanges: { [key: string]: IExchangeService } = {}
 
@@ -56,6 +57,9 @@ export const ExchangeFactory = (): ExchangeFactory => {
         break
       case "ibex":
         service = await createIbex(config)
+        break
+      case "ibex-swap":
+        service = await createIbexSwap(config)
         break
     }
     if (service instanceof Error) return service
@@ -133,6 +137,16 @@ const createIbex = async (config: ExchangeConfig) => {
   const { base, quote } = config
   const defaultConfig = { timeout: 5000 }
   return IbexExchangeService({
+    base: base,
+    quote: quote,
+    config: { ...defaultConfig, ...config.config },
+  })
+}
+
+const createIbexSwap = async (config: ExchangeConfig) => {
+  const { base, quote } = config
+  const defaultConfig = { timeout: 5000 }
+  return IbexSwapExchangeService({
     base: base,
     quote: quote,
     config: { ...defaultConfig, ...config.config },

--- a/realtime/test/unit/services/exchanges/ibex-swap.spec.ts
+++ b/realtime/test/unit/services/exchanges/ibex-swap.spec.ts
@@ -1,0 +1,292 @@
+import axios from "axios"
+
+import { toPrice, toTimestamp } from "@domain/primitives"
+import {
+  ExchangeServiceError,
+  InvalidExchangeResponseError,
+  UnknownExchangeServiceError,
+} from "@domain/exchanges"
+
+import * as LocalCacheServiceImpl from "@services/cache"
+import { IbexSwapExchangeService } from "@services/exchanges/ibex-swap"
+
+// Live sandbox response for GET /rates?from=2&to=3 (BTC→USD). BOTH fields are
+// in USD-per-BTC: rate = selling BTC (bid side), inverseRate = the other side
+// of the same market (ask side) — NOT a reciprocal, each side has its own fee.
+// (The USD→BTC direction returns both sides in BTC-per-USD the same way,
+// e.g. { rate: 0.00001542, inverseRate: 0.00001563 }.)
+const mockSwapRatesBody = {
+  rate: 63968.8481,
+  inverseRate: 64870.7251,
+}
+
+const mockAxiosResponse = {
+  data: mockSwapRatesBody,
+  status: 200,
+}
+
+jest.mock("axios")
+
+jest.mock("ibex-client", () => {
+  // minimal stand-in for IbexAuthentication.withAuth: unwraps `.data`,
+  // refreshes + retries exactly once when the call throws { status: 401 }
+  const withAuth = jest.fn(
+    async (apiCall: () => Promise<{ data: unknown }>): Promise<unknown> => {
+      try {
+        return (await apiCall()).data
+      } catch (err) {
+        if ((err as { status?: number })?.status === 401) return (await apiCall()).data
+        throw err
+      }
+    },
+  )
+  return {
+    __esModule: true,
+    default: jest.fn().mockImplementation(() => ({
+      authentication: {
+        withAuth,
+        storage: { getAccessToken: jest.fn(async () => "test-token") },
+      },
+    })),
+    IbexUrls: {
+      production: { hubUrl: "https://ibexhub-api.poweredbyibex.io" },
+      sandbox: { hubUrl: "https://ibexhub-api.sandbox.poweredbyibex.io" },
+    },
+  }
+})
+
+const mockLocalCache = ({
+  get = () => Promise.resolve(new Error()),
+  set = jest.fn(),
+}: {
+  get?: <T>(key: string) => Promise<T | Error>
+  set?: jest.Mock
+} = {}) => {
+  jest.spyOn(LocalCacheServiceImpl, "LocalCacheService").mockImplementation(() => ({
+    get: get as never,
+    getOrSet: jest.fn(),
+    set,
+    clear: jest.fn(),
+  }))
+  return { set }
+}
+
+describe("IbexSwapExchangeService", () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockLocalCache()
+  })
+
+  it("should return a bid/ask ticker from rate and inverseRate", async () => {
+    ;(axios.get as jest.Mock).mockResolvedValue(mockAxiosResponse)
+
+    const service = await IbexSwapExchangeService({
+      base: "BTC",
+      quote: "USD",
+      config: { cacheSeconds: 300 },
+    })
+    if (service instanceof Error) throw service
+
+    const result = await service.fetchTicker()
+    expect(axios.get).toHaveBeenCalledWith(
+      // hubUrl of whichever environment @config resolves (post-#9 the default
+      // without IBEX_ENVIRONMENT is production) — what matters here is the
+      // hub host family + /rates path, not the env.
+      expect.stringMatching(
+        /^https:\/\/ibexhub-api(\.sandbox)?\.poweredbyibex\.io\/rates$/,
+      ),
+      expect.objectContaining({
+        // raw JWT — IBEX rejects a "Bearer " prefix (apiKey-in-header scheme)
+        headers: { Authorization: "test-token" },
+        params: { from: 2, to: 3 }, // IBEX currency ids for BTC / USD
+        timeout: 5000,
+      }),
+    )
+    expect(result).toEqual({
+      bid: toPrice(63968.8481),
+      ask: toPrice(64870.7251),
+      timestamp: toTimestamp(expect.any(Number)),
+    })
+  })
+
+  it("should keep bid <= ask regardless of which side is larger", async () => {
+    ;(axios.get as jest.Mock).mockResolvedValue({
+      // pathological direction: rate side above the inverseRate side
+      data: { rate: 64870.7251, inverseRate: 63968.8481 },
+      status: 200,
+    })
+
+    const service = await IbexSwapExchangeService({
+      base: "BTC",
+      quote: "USD",
+      config: {},
+    })
+    if (service instanceof Error) throw service
+
+    const result = await service.fetchTicker()
+    if (result instanceof Error) throw result
+    expect(result.bid).toBeLessThanOrEqual(result.ask)
+    expect(result.bid).toBeCloseTo(63968.8481)
+    expect(result.ask).toBeCloseTo(64870.7251)
+  })
+
+  it("should return ExchangeServiceError if currency has no IBEX id", async () => {
+    const service = await IbexSwapExchangeService({
+      base: "BTC",
+      quote: "XXX",
+      config: {},
+    })
+    if (service instanceof Error) throw service
+
+    const result = await service.fetchTicker()
+    expect(result).toBeInstanceOf(ExchangeServiceError)
+    expect(axios.get).not.toHaveBeenCalled()
+  })
+
+  it("should return UnknownExchangeServiceError and cache the status on HTTP error", async () => {
+    ;(axios.get as jest.Mock).mockResolvedValue({ data: {}, status: 500 })
+    const { set } = mockLocalCache()
+
+    const service = await IbexSwapExchangeService({
+      base: "BTC",
+      quote: "USD",
+      config: {},
+    })
+    if (service instanceof Error) throw service
+
+    const result = await service.fetchTicker()
+    expect(result).toBeInstanceOf(UnknownExchangeServiceError)
+    expect(set).toHaveBeenCalledWith(expect.objectContaining({ value: 500 }))
+  })
+
+  it("should back off without calling the API if the last request errored", async () => {
+    mockLocalCache({
+      get: <T>(key: string) =>
+        Promise.resolve(key.endsWith(":status") ? (503 as T) : new Error()),
+    })
+
+    const service = await IbexSwapExchangeService({
+      base: "BTC",
+      quote: "USD",
+      config: {},
+    })
+    if (service instanceof Error) throw service
+
+    const result = await service.fetchTicker()
+    expect(result).toBeInstanceOf(UnknownExchangeServiceError)
+    expect(axios.get).not.toHaveBeenCalled()
+  })
+
+  it("should return UnknownExchangeServiceError if the request fails", async () => {
+    ;(axios.get as jest.Mock).mockRejectedValue(new Error("timeout of 5000ms exceeded"))
+
+    const service = await IbexSwapExchangeService({
+      base: "BTC",
+      quote: "USD",
+      config: {},
+    })
+    if (service instanceof Error) throw service
+
+    const result = await service.fetchTicker()
+    expect(result).toBeInstanceOf(UnknownExchangeServiceError)
+  })
+
+  it("should return InvalidExchangeResponseError if body is malformed", async () => {
+    ;(axios.get as jest.Mock).mockResolvedValue({
+      data: { rate: "not-a-number" },
+      status: 200,
+    })
+
+    const service = await IbexSwapExchangeService({
+      base: "BTC",
+      quote: "USD",
+      config: {},
+    })
+    if (service instanceof Error) throw service
+
+    const result = await service.fetchTicker()
+    expect(result).toBeInstanceOf(InvalidExchangeResponseError)
+  })
+
+  it("should retry once through withAuth when the API returns 401", async () => {
+    ;(axios.get as jest.Mock)
+      .mockResolvedValueOnce({ data: {}, status: 401 })
+      .mockResolvedValueOnce(mockAxiosResponse)
+
+    const service = await IbexSwapExchangeService({
+      base: "BTC",
+      quote: "USD",
+      config: {},
+    })
+    if (service instanceof Error) throw service
+
+    const result = await service.fetchTicker()
+    expect(axios.get).toHaveBeenCalledTimes(2)
+    expect(result).toEqual({
+      bid: toPrice(63968.8481),
+      ask: toPrice(64870.7251),
+      timestamp: toTimestamp(expect.any(Number)),
+    })
+  })
+
+  it("should return UnknownExchangeServiceError if still 401 after the retry", async () => {
+    ;(axios.get as jest.Mock).mockResolvedValue({ data: {}, status: 401 })
+
+    const service = await IbexSwapExchangeService({
+      base: "BTC",
+      quote: "USD",
+      config: {},
+    })
+    if (service instanceof Error) throw service
+
+    const result = await service.fetchTicker()
+    expect(axios.get).toHaveBeenCalledTimes(2)
+    expect(result).toBeInstanceOf(UnknownExchangeServiceError)
+  })
+
+  it("should use cached rates without calling the API", async () => {
+    mockLocalCache({
+      get: <T>(key: string) =>
+        Promise.resolve(
+          key.endsWith(":status")
+            ? (new Error() as unknown as T)
+            : ({ rate: 63968.8481, inverseRate: 64870.7251 } as T),
+        ),
+    })
+
+    const service = await IbexSwapExchangeService({
+      base: "BTC",
+      quote: "USD",
+      config: { cacheSeconds: 300 },
+    })
+    if (service instanceof Error) throw service
+
+    const result = await service.fetchTicker()
+    expect(axios.get).not.toHaveBeenCalled()
+    expect(result).toEqual({
+      bid: toPrice(63968.8481),
+      ask: toPrice(64870.7251),
+      timestamp: toTimestamp(expect.any(Number)),
+    })
+  })
+
+  it("should cache fetched rates for cacheSeconds", async () => {
+    ;(axios.get as jest.Mock).mockResolvedValue(mockAxiosResponse)
+    const { set } = mockLocalCache()
+
+    const service = await IbexSwapExchangeService({
+      base: "BTC",
+      quote: "USD",
+      config: { cacheSeconds: 300 },
+    })
+    if (service instanceof Error) throw service
+
+    await service.fetchTicker()
+    expect(set).toHaveBeenCalledWith(
+      expect.objectContaining({
+        value: { rate: 63968.8481, inverseRate: 64870.7251 },
+        ttlSecs: 300,
+      }),
+    )
+  })
+})


### PR DESCRIPTION
## Why

IBEX is steering partners toward the **Swap Rates** endpoint (`GET /rates?from={currency_id}&to={currency_id}`, [docs](https://docs.poweredbyibex.io/reference/swap-rates)), which returns `rate` and `inverseRate` **inclusive of fee/spread** — i.e. the rates IBEX will actually execute at. The legacy **Rates v2** endpoint (`GET /v2/currencies/rate/{a}/{b}`, used by the existing `ibex` provider) is mid-market-ish and display-only.

This adds a **new** `ibex-swap` provider instead of changing `ibex`, so ops can A/B the two purely via config:

- **TEST** runs `provider: "ibex-swap"`
- **prod** stays on `provider: "ibex"` (Rates v2) — zero behavior change there

Aligning the displayed price with the executable price removes the LNURL sizing slippage we see when a quote is built from a display-only rate and then settled at the fee-inclusive swap rate.

## Live sandbox verification

Exercised with real sandbox credentials against the client lib's hub base URL (`ibexhub-api.sandbox.poweredbyibex.io`) — the endpoint exists there and the response shape is confirmed:

- `GET /rates?from=2&to=3` (BTC→USD): `{"rate":63968.8481,"inverseRate":64870.7251}` — **both** in USD-per-BTC
- `GET /rates?from=3&to=2` (USD→BTC): `{"rate":0.00001542,"inverseRate":0.00001563}` — both in BTC-per-USD

So for `from=base&to=quote`: `rate` = executable sell side (bid) and `inverseRate` = the other side of the same market (ask), in the **same units** — not a reciprocal (each direction carries its own fee). Rates v2 mid at the same moment (~64,407) sat between the two sides: **~0.7% spread each way**. These two live responses are the unit-test fixtures.

**Auth quirk:** the API expects the **raw JWT** in the `Authorization` header — a `Bearer ` prefix is rejected with 401 (the SDK's openapi security scheme is apiKey-in-header named `Authorization`, not http-bearer; that's why `sdk.auth(token)` works). Verified live in both directions.

## What

- `realtime/src/services/exchanges/ibex-swap/` — new provider. Same base-URL/environment resolution (`IbexUrls[IBEX.environment].hubUrl`, production vs sandbox) and same credentials as the `ibex` provider.
- **Auth reuse**: `ibex-client` doesn't expose `GET /rates`, so the provider issues the call directly with axios (raw-JWT `Authorization` header, per above) but wraps it in `IbexClient.authentication.withAuth(...)` — the lib's existing oauth client-credentials flow, shared redis token cache (`ibex:accessToken`), and refresh-then-retry-once-on-401 semantics all apply unchanged. No oauth reimplementation.
- **Price mapping**: `bid = min(rate, inverseRate)`, `ask = max(rate, inverseRate)` (min/max keeps `bid <= ask` however fees land — no `1/x` anywhere). Ticker shape matches the existing providers, so downstream mid/median logic is unchanged.
- **Config**: same keys as `ibex` (`cacheSeconds`, `timeout`); `"ibex-swap"` added to the provider enum in `realtime/src/config/schema.ts`; registered in the `ExchangeFactory` switch; disabled sample entry in `realtime/sample-dev-custom.yaml`.
- `getIbexId` is now exported from the `ibex` provider so both share one currency-id map (no behavior change to `ibex`).
- On HTTP >= 400 the status is cached for the TTL and subsequent calls back off (same intent as the `ibex` provider's status gate, but storing the real status code).
- 11 unit tests: happy path (live fixture), bid/ask ordering, unknown currency id, HTTP error + status caching, back-off, network failure, malformed body, 401 refresh-retry (success and exhaustion), cache read/write.

## Test/build results

```
$ yarn jest --config ./test/jest-unit.config.js --ci ibex-swap
Test Suites: 1 passed, 1 total
Tests:       11 passed, 11 total

$ yarn jest --config ./test/jest-unit.config.js --ci   # full realtime unit suite
Test Suites: 1 failed, 6 passed, 7 total
Tests:       1 failed, 36 passed, 37 total
```
The single failure is `test/unit/config/yaml.spec.ts` ("returns correct country codes for a valid currency") — **pre-existing on a clean `main` checkout**, unrelated to this change (verified via `git stash`). All 11 new `ibex-swap.spec.ts` tests pass.

```
$ yarn tsc-check   # exit 0
$ yarn build       # exit 0 (dist includes services/exchanges/ibex-swap)
$ yarn eslint <changed files>   # exit 0
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)